### PR TITLE
Fix getContainersListCrypttab

### DIFF
--- a/usr/share/openmediavault/engined/rpc/luks.inc
+++ b/usr/share/openmediavault/engined/rpc/luks.inc
@@ -179,8 +179,9 @@ class OMVRpcServiceLuksMgmt extends \OMV\Rpc\ServiceAbstract {
         $this->validateMethodParams($params, "rpc.common.getlist");
         // Enumerate all LUKS containers on the system.
         $containers = $this->callMethod("getContainersList", $params, $context)['data'];
+        $result = [];
         foreach ($containers as $luksk => $luksv) {
-            // Filter all devices that are already in the crypttab            
+            // Filter all devices that are already in the crypttab
             if ($luksv['crypttabregistration'] === TRUE)
                 continue;
             $result[] = [


### PR DESCRIPTION
This PR fixes the RPC response when we're trying to enumerate block devices in Crypttab management (eg. when adding new Crypttab entry). Previously, it would load the RPC response and the list of devices would spin indefinitely (with an TypeError displayed in Devtool's console, indicating that the framework was not able to understand the response). Now, it will properly handle the "empty list" case.

### Bug description

- When "Block devices" list in Crypttab management modal is empty, opening up the list will "spin" indefinitely

### Steps to reproduce

1. Go to ``Storage > Encryption > Crypttab`` section
2. Make sure there are no Block devices available to add as new Crypttab entries (eg. when none of the devices has been encrypted yet)
3. Open up "Add" modal
4. Try to select a Block device from the list (open the list)
5. Wait for the RPC response

### Expected result

- The list stops spinning and is displayed as "empty"

### Actual result

- The list spins indefinitely
- A TypeError shows up in Devtool's Console:
  > TypeError: c is null; can't access its "status" property